### PR TITLE
Compiler fixes

### DIFF
--- a/src/ChannelPacket.cpp
+++ b/src/ChannelPacket.cpp
@@ -56,9 +56,6 @@ ChannelPacket::ChannelPacket(ChannelPacketType packtype, uint64_t virtualAddr, u
 ChannelPacket::ChannelPacket() {}
 
 void ChannelPacket::print(uint64_t currentClockCycle){
-	if (this == NULL)
-		return;
-
 	PRINT("Cycle: "<<currentClockCycle<<" Type: " << busPacketType << " addr: "<<physicalAddress<<" package: "<<package<<" die: "<<die<<" plane: "<<
 			plane<<" block: "<<block<<" page: "<<page<<" data: "<<data);
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -34,6 +34,7 @@
 #ifndef NVDIMM_UTIL_H
 #define NVDIMM_UTIL_H
 
+#include <cstdint>
 #include <string>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
On GCC 13.2.0,
- the missing header causes a compile error
- the null comparison causes a compile warning